### PR TITLE
Change log location from data to cache stdpath.

### DIFF
--- a/log.lua
+++ b/log.lua
@@ -45,7 +45,7 @@ local unpack = unpack or table.unpack
 log.new = function(config, standalone)
   config = vim.tbl_deep_extend("force", default_config, config)
 
-  local outfile = string.format('%s/%s.log', vim.api.nvim_call_function('stdpath', {'data'}), config.plugin)
+  local outfile = string.format('%s/%s.log', vim.fn.stdpath('cache'), config.plugin)
 
   local obj
   if standalone then


### PR DESCRIPTION
As a follow-up to the changes in neovim changing the default log
location, I figured it'd be good for this to follow suit.
https://github.com/neovim/neovim/pull/13739

NOTE: If you're hesitant to change this now since it would switch stuff
for current plugins that are using it, no worries. I recently used this
to figure out my own logging in [nvim-metals](https://github.com/scalameta/nvim-metals/blob/master/lua/metals/log.lua), even though I pretty radically changed it. However,
thanks for this, it was super helpful to get started with 🙏🏼 .