### PR TITLE
Wrap console printing to work in jobs

### DIFF
--- a/log.lua
+++ b/log.lua
@@ -5,7 +5,6 @@
 --
 -- This library is free software; you can redistribute it and/or modify it
 -- under the terms of the MIT license. See LICENSE for details.
-
 -- User configuration section
 local default_config = {
   -- Name of the plugin. Prepended to log messages
@@ -25,16 +24,13 @@ local default_config = {
 
   -- Level configuration
   modes = {
-    { name = "trace", hl = "Comment", },
-    { name = "debug", hl = "Comment", },
-    { name = "info",  hl = "None", },
-    { name = "warn",  hl = "WarningMsg", },
-    { name = "error", hl = "ErrorMsg", },
-    { name = "fatal", hl = "ErrorMsg", },
+    {name = "trace", hl = "Comment"}, {name = "debug", hl = "Comment"},
+    {name = "info", hl = "None"}, {name = "warn", hl = "WarningMsg"},
+    {name = "error", hl = "ErrorMsg"}, {name = "fatal", hl = "ErrorMsg"}
   },
 
   -- Can limit the number of decimals displayed for floats
-  float_precision = 0.01,
+  float_precision = 0.01
 }
 
 -- {{{ NO NEED TO CHANGE
@@ -45,7 +41,8 @@ local unpack = unpack or table.unpack
 log.new = function(config, standalone)
   config = vim.tbl_deep_extend("force", default_config, config)
 
-  local outfile = string.format('%s/%s.log', vim.api.nvim_call_function('stdpath', {'data'}), config.plugin)
+  local outfile = string.format('%s/%s.log', vim.api.nvim_call_function('stdpath', {'data'}),
+                                config.plugin)
 
   local obj
   if standalone then
@@ -55,9 +52,7 @@ log.new = function(config, standalone)
   end
 
   local levels = {}
-  for i, v in ipairs(config.modes) do
-    levels[v.name] = i
-  end
+  for i, v in ipairs(config.modes) do levels[v.name] = i end
 
   local round = function(x, increment)
     increment = increment or 1
@@ -83,12 +78,26 @@ log.new = function(config, standalone)
     return table.concat(t, " ")
   end
 
+  local console_output = vim.schedule_wrap(function(level_config, info, nameupper, msg)
+    local console_lineinfo = vim.fn.fnamemodify(info.short_src, ':t') .. ':' .. info.currentline
+    local console_string = string.format("[%-6s%s] %s: %s", nameupper, os.date("%H:%M:%S"),
+                                         console_lineinfo, msg)
+
+    if config.highlights and level_config.hl then
+      vim.cmd(string.format("echohl %s", level_config.hl))
+    end
+
+    local split_console = vim.split(console_string, "\n")
+    for _, v in ipairs(split_console) do
+      vim.cmd(string.format([[echom "[%s] %s"]], config.plugin, vim.fn.escape(v, '"')))
+    end
+
+    if config.highlights and level_config.hl then vim.cmd("echohl NONE") end
+  end)
 
   local log_at_level = function(level, level_config, message_maker, ...)
     -- Return early if we're below the config.level
-    if level < levels[config.level] then
-      return
-    end
+    if level < levels[config.level] then return end
     local nameupper = level_config.name:upper()
 
     local msg = message_maker(...)
@@ -96,52 +105,26 @@ log.new = function(config, standalone)
     local lineinfo = info.short_src .. ":" .. info.currentline
 
     -- Output to console
-    if config.use_console then
-      local console_string = string.format(
-      "[%-6s%s] %s: %s",
-      nameupper,
-      os.date("%H:%M:%S"),
-      lineinfo,
-      msg
-      )
-
-      if config.highlights and level_config.hl then
-        vim.cmd(string.format("echohl %s", level_config.hl))
-      end
-
-      local split_console = vim.split(console_string, "\n")
-      for _, v in ipairs(split_console) do
-        vim.cmd(string.format([[echom "[%s] %s"]], config.plugin, vim.fn.escape(v, '"')))
-      end
-
-      if config.highlights and level_config.hl then
-        vim.cmd("echohl NONE")
-      end
-    end
+    if config.use_console then console_output(level_config, info, nameupper, msg) end
 
     -- Output to log file
     if config.use_file then
       local fp = io.open(outfile, "a")
-      local str = string.format("[%-6s%s] %s: %s\n",
-      nameupper, os.date(), lineinfo, msg)
+      local str = string.format("[%-6s%s] %s: %s\n", nameupper, os.date(), lineinfo, msg)
       fp:write(str)
       fp:close()
     end
   end
 
   for i, x in ipairs(config.modes) do
-    obj[x.name] = function(...)
-      return log_at_level(i, x, make_string, ...)
-    end
+    obj[x.name] = function(...) return log_at_level(i, x, make_string, ...) end
 
-    obj[("fmt_%s" ):format(x.name)] = function()
+    obj[("fmt_%s"):format(x.name)] = function()
       return log_at_level(i, x, function(...)
         local passed = {...}
         local fmt = table.remove(passed, 1)
         local inspected = {}
-        for _, v in ipairs(passed) do
-          table.insert(inspected, vim.inspect(v))
-        end
+        for _, v in ipairs(passed) do table.insert(inspected, vim.inspect(v)) end
         return string.format(fmt, unpack(inspected))
       end)
     end


### PR DESCRIPTION
I slightly restructured console logging to move most of the logic to a function wrapped with `vim.schedule_wrap`. That allows `vlog` to be used from within jobs.

I also modified the console output format to just print the filename (rather than the entire `info.short_src` path, which I found was still so long as to cut off most of the message), and ran `lua-format` (I'm happy to undo these changes).